### PR TITLE
erro, colocando mensagens em pendente

### DIFF
--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -704,7 +704,7 @@ export class ChatwootService {
           conversation = contactConversations.payload.find((conversation) => conversation.inbox_id == filterInbox.id);
           this.logger.verbose(`Found conversation in reopenConversation mode: ${JSON.stringify(conversation)}`);
 
-          if (this.provider.conversationPending) {
+          if (this.provider.conversationPending && conversation.status !== 'open') {
             if (conversation) {
               await client.conversations.toggleStatus({
                 accountId: this.provider.accountId,


### PR DESCRIPTION
Quando o cliente manda mensagem e a conversa já está aberta, ela é colocada como pendente, corrigimos validando se o status da conversa não está como open.